### PR TITLE
fix: Allow CI to create tag AND release

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -24,3 +24,5 @@ jobs:
         run: git tag ${{ steps.svu.outputs.version }}
       - name: Push tag to origin
         run: git push origin ${{ steps.svu.outputs.version }}
+  release:
+    uses: ./.github/workflows/release.yaml

--- a/.github/workflows/on_tag.yaml
+++ b/.github/workflows/on_tag.yaml
@@ -1,0 +1,10 @@
+name: Release On Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    uses: ./.github/workflows/release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
 
 permissions:
   contents: write


### PR DESCRIPTION
Github won't trigger subsequent actions, if the caller was an action. So we call the code directly in our trigger