### PR TITLE
feat: Add detailed outlines

### DIFF
--- a/src/main/java/richiesams/omniconduit/mixin/WorldRendererMixin.java
+++ b/src/main/java/richiesams/omniconduit/mixin/WorldRendererMixin.java
@@ -1,0 +1,50 @@
+package richiesams.omniconduit.mixin;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import richiesams.omniconduit.blocks.ConduitBundleBlock;
+
+@Environment(EnvType.CLIENT)
+@Mixin(WorldRenderer.class)
+public abstract class WorldRendererMixin {
+    @Accessor
+    abstract ClientWorld getWorld();
+
+    @Accessor
+    abstract MinecraftClient getClient();
+
+    @Invoker("drawCuboidShapeOutline")
+    public static void drawCuboidShapeOutline(MatrixStack matrices, VertexConsumer vertexConsumer, VoxelShape shape, double offsetX, double offsetY, double offsetZ, float red, float green, float blue, float alpha) {
+        throw new AssertionError();
+    }
+
+    @Inject(at = @At("HEAD"), method = "drawBlockOutline", cancellable = true)
+    private void drawBlockOutline(MatrixStack matrices, VertexConsumer vertexConsumer, Entity entity, double cameraX, double cameraY, double cameraZ, BlockPos pos, BlockState state, CallbackInfo ci) {
+        if (state.getBlock() instanceof ConduitBundleBlock conduitBundleBlock) {
+            var world = getWorld();
+            var client = getClient();
+
+            // Draw our custom outline
+            var outline = conduitBundleBlock.getDetailedOutlineShape(client, world, pos);
+            WorldRendererMixin.drawCuboidShapeOutline(matrices, vertexConsumer, outline, (double) pos.getX() - cameraX, (double) pos.getY() - cameraY, (double) pos.getZ() - cameraZ, 0.0f, 0.0f, 0.0f, 0.4f);
+
+            // Return early, so the "real" method doesn't also draw an outline
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/kotlin/richiesams/omniconduit/api/conduits/ConduitConnection.kt
+++ b/src/main/kotlin/richiesams/omniconduit/api/conduits/ConduitConnection.kt
@@ -2,12 +2,18 @@ package richiesams.omniconduit.api.conduits
 
 data class ConduitConnection(
     val type: ConduitConnectionType,
-    val input: Boolean,
-    val output: Boolean
+    val terminationMode: ConduitTerminationMode
 )
 
 enum class ConduitConnectionType {
-    CONDUIT,
-    CONDUIT_SINGLE,
+    SINGLE_CONDUIT,
+    MULTI_CONDUIT,
     TERMINATION,
+}
+
+enum class ConduitTerminationMode {
+    NONE,
+    INPUT_OUTPUT,
+    INPUT_ONLY,
+    OUTPUT_ONLY
 }

--- a/src/main/kotlin/richiesams/omniconduit/api/conduits/ConduitEntity.kt
+++ b/src/main/kotlin/richiesams/omniconduit/api/conduits/ConduitEntity.kt
@@ -32,10 +32,9 @@ abstract class ConduitEntity protected constructor(
             val direction: Direction =
                 Direction.byName(connection.getString("Direction")) ?: throw RuntimeException("Invalid direction value")
             val connectionType = ConduitConnectionType.valueOf(connection.getString("Type"))
-            val input = connection.getBoolean("Input")
-            val output = connection.getBoolean("Output")
+            val terminationMode = ConduitTerminationMode.valueOf(connection.getString("TerminationMode"))
 
-            newConnections[direction] = ConduitConnection(connectionType, input, output)
+            newConnections[direction] = ConduitConnection(connectionType, terminationMode)
         }
 
         this.connections = newConnections
@@ -48,8 +47,7 @@ abstract class ConduitEntity protected constructor(
             val connection = NbtCompound()
             connection.putString("Direction", entry.key.toString())
             connection.putString("Type", entry.value.type.toString())
-            connection.putBoolean("Input", entry.value.input)
-            connection.putBoolean("Output", entry.value.output)
+            connection.putString("TerminationMode", entry.value.terminationMode.toString())
 
             connectionsList.add(connection)
         }

--- a/src/main/kotlin/richiesams/omniconduit/api/conduits/ConduitRenderShape.kt
+++ b/src/main/kotlin/richiesams/omniconduit/api/conduits/ConduitRenderShape.kt
@@ -4,12 +4,10 @@ import net.minecraft.util.math.Box
 import net.minecraft.util.math.Direction
 import richiesams.omniconduit.util.SpriteReference
 
-class ConduitShape(
+class ConduitRenderShape(
     val cores: List<CoreShape>,
     val connections: List<ConnectionShape>,
-    val outlines: List<Box>,
-) {
-}
+)
 
 class CoreShape(
     val type: String,

--- a/src/main/kotlin/richiesams/omniconduit/blocks/ConduitBundleBlock.kt
+++ b/src/main/kotlin/richiesams/omniconduit/blocks/ConduitBundleBlock.kt
@@ -5,9 +5,12 @@ import net.minecraft.block.*
 import net.minecraft.block.entity.BlockEntity
 import net.minecraft.block.entity.BlockEntityTicker
 import net.minecraft.block.entity.BlockEntityType
+import net.minecraft.client.MinecraftClient
+import net.minecraft.client.world.ClientWorld
 import net.minecraft.state.StateManager
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.shape.VoxelShape
+import net.minecraft.util.shape.VoxelShapes
 import net.minecraft.world.BlockView
 import net.minecraft.world.World
 import richiesams.omniconduit.api.blockentities.ConduitBundleBlockEntity
@@ -42,10 +45,19 @@ class ConduitBundleBlock(settings: Settings?) : BlockWithEntity(settings), Block
     override fun getOutlineShape(state: BlockState?, world: BlockView, pos: BlockPos?, context: ShapeContext?): VoxelShape {
         val blockEntity: BlockEntity? = world.getBlockEntity(pos)
         if (blockEntity is ConduitBundleBlockEntity) {
-            return blockEntity.getOutlineShape()
+            return blockEntity.getBoundingBoxShape()
         }
 
         return super.getOutlineShape(state, world, pos, context)
+    }
+
+    fun getDetailedOutlineShape(client: MinecraftClient, world: ClientWorld, pos: BlockPos?): VoxelShape {
+        val blockEntity: BlockEntity? = world.getBlockEntity(pos)
+        if (blockEntity is ConduitBundleBlockEntity) {
+            return blockEntity.getOutlineShape(client)
+        }
+
+        return VoxelShapes.empty()
     }
 
     override fun neighborUpdate(state: BlockState?, world: World?, pos: BlockPos?, sourceBlock: Block?, sourcePos: BlockPos?, notify: Boolean) {

--- a/src/main/kotlin/richiesams/omniconduit/conduitentities/EnergyConduitEntity.kt
+++ b/src/main/kotlin/richiesams/omniconduit/conduitentities/EnergyConduitEntity.kt
@@ -7,10 +7,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import richiesams.omniconduit.api.BlockApiLookups
 import richiesams.omniconduit.api.blockentities.ConduitBundleBlockEntity
-import richiesams.omniconduit.api.conduits.Conduit
-import richiesams.omniconduit.api.conduits.ConduitConnection
-import richiesams.omniconduit.api.conduits.ConduitConnectionType
-import richiesams.omniconduit.api.conduits.ConduitEntity
+import richiesams.omniconduit.api.conduits.*
 
 class EnergyConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntity) : ConduitEntity(conduit, blockEntity) {
     private val adjacentConduitBundles: Array<BlockApiCache<ConduitBundleBlockEntity, Unit>?> = arrayOfNulls(6)
@@ -36,9 +33,9 @@ class EnergyConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntit
                 if (otherConduitBundle != null) {
                     if (otherConduitBundle.hasConduitOfType(conduit.javaClass)) {
                         if (otherConduitBundle.conduitCount() == 1) {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT_SINGLE, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.SINGLE_CONDUIT, ConduitTerminationMode.NONE)
                         } else {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.MULTI_CONDUIT, ConduitTerminationMode.NONE)
                         }
 
                         markDirty = true

--- a/src/main/kotlin/richiesams/omniconduit/conduitentities/FluidConduitEntity.kt
+++ b/src/main/kotlin/richiesams/omniconduit/conduitentities/FluidConduitEntity.kt
@@ -7,10 +7,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import richiesams.omniconduit.api.BlockApiLookups
 import richiesams.omniconduit.api.blockentities.ConduitBundleBlockEntity
-import richiesams.omniconduit.api.conduits.Conduit
-import richiesams.omniconduit.api.conduits.ConduitConnection
-import richiesams.omniconduit.api.conduits.ConduitConnectionType
-import richiesams.omniconduit.api.conduits.ConduitEntity
+import richiesams.omniconduit.api.conduits.*
 
 class FluidConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntity) : ConduitEntity(conduit, blockEntity) {
     private val adjacentConduitBundles: Array<BlockApiCache<ConduitBundleBlockEntity, Unit>?> = arrayOfNulls(6)
@@ -36,9 +33,9 @@ class FluidConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntity
                 if (otherConduitBundle != null) {
                     if (otherConduitBundle.hasConduitOfType(conduit.javaClass)) {
                         if (otherConduitBundle.conduitCount() == 1) {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT_SINGLE, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.SINGLE_CONDUIT, ConduitTerminationMode.NONE)
                         } else {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.MULTI_CONDUIT, ConduitTerminationMode.NONE)
                         }
 
                         markDirty = true

--- a/src/main/kotlin/richiesams/omniconduit/conduitentities/ItemConduitEntity.kt
+++ b/src/main/kotlin/richiesams/omniconduit/conduitentities/ItemConduitEntity.kt
@@ -7,10 +7,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import richiesams.omniconduit.api.BlockApiLookups
 import richiesams.omniconduit.api.blockentities.ConduitBundleBlockEntity
-import richiesams.omniconduit.api.conduits.Conduit
-import richiesams.omniconduit.api.conduits.ConduitConnection
-import richiesams.omniconduit.api.conduits.ConduitConnectionType
-import richiesams.omniconduit.api.conduits.ConduitEntity
+import richiesams.omniconduit.api.conduits.*
 
 class ItemConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntity) : ConduitEntity(conduit, blockEntity) {
     private val adjacentConduitBundles: Array<BlockApiCache<ConduitBundleBlockEntity, Unit>?> = arrayOfNulls(6)
@@ -36,9 +33,9 @@ class ItemConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntity)
                 if (otherConduitBundle != null) {
                     if (otherConduitBundle.hasConduitOfType(conduit.javaClass)) {
                         if (otherConduitBundle.conduitCount() == 1) {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT_SINGLE, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.SINGLE_CONDUIT, ConduitTerminationMode.NONE)
                         } else {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.MULTI_CONDUIT, ConduitTerminationMode.NONE)
                         }
 
                         markDirty = true

--- a/src/main/kotlin/richiesams/omniconduit/conduitentities/RedstoneConduitEntity.kt
+++ b/src/main/kotlin/richiesams/omniconduit/conduitentities/RedstoneConduitEntity.kt
@@ -7,10 +7,7 @@ import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import richiesams.omniconduit.api.BlockApiLookups
 import richiesams.omniconduit.api.blockentities.ConduitBundleBlockEntity
-import richiesams.omniconduit.api.conduits.Conduit
-import richiesams.omniconduit.api.conduits.ConduitConnection
-import richiesams.omniconduit.api.conduits.ConduitConnectionType
-import richiesams.omniconduit.api.conduits.ConduitEntity
+import richiesams.omniconduit.api.conduits.*
 
 
 class RedstoneConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEntity) : ConduitEntity(conduit, blockEntity) {
@@ -37,9 +34,9 @@ class RedstoneConduitEntity(conduit: Conduit, blockEntity: ConduitBundleBlockEnt
                 if (otherConduitBundle != null) {
                     if (otherConduitBundle.hasConduitOfType(conduit.javaClass)) {
                         if (otherConduitBundle.conduitCount() == 1) {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT_SINGLE, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.SINGLE_CONDUIT, ConduitTerminationMode.NONE)
                         } else {
-                            connections[direction] = ConduitConnection(ConduitConnectionType.CONDUIT, input = false, output = false)
+                            connections[direction] = ConduitConnection(ConduitConnectionType.MULTI_CONDUIT, ConduitTerminationMode.NONE)
                         }
 
                         markDirty = true

--- a/src/main/kotlin/richiesams/omniconduit/rendering/ConduitBundleBlockEntityRenderer.kt
+++ b/src/main/kotlin/richiesams/omniconduit/rendering/ConduitBundleBlockEntityRenderer.kt
@@ -69,7 +69,7 @@ class ConduitBundleBlockEntityRenderer(ctx: BlockEntityRendererFactory.Context?)
     private class WireFrameCuboidFace(val direction: Direction, val cube: Box, val uvRotation: Rotation) {}
 
     override fun render(entity: ConduitBundleBlockEntity, tickDelta: Float, matrices: MatrixStack, vertexConsumers: VertexConsumerProvider, light: Int, overlay: Int) {
-        val shape = entity.getConduitShape()
+        val shape = entity.getRenderShape()
 
         matrices.push()
 

--- a/src/main/resources/omniconduit.client.mixins.json
+++ b/src/main/resources/omniconduit.client.mixins.json
@@ -3,7 +3,8 @@
   "package": "richiesams.omniconduit.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "MouseMixin"
+    "MouseMixin",
+    "WorldRendererMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Each part of a conduit (core, connection, termination) can be individually highlighted.

Unfortunately, the Minecraft API uses a single function for both outlines and collision/ray tracing. We don't want collision/ray tracing to use the detailed boxes, because it's very expensive.

So we use a Mixin to override outline drawing for the ConduitBundle block, and use our detailed outline function. And leave the simple bounding box for collision / ray tracing